### PR TITLE
Update version sync with spatie/laravel-backup

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "php": ">=7.0.0",
         "laravel/framework": "5.5.*",
         "encore/laravel-admin": "1.5.*",
-        "spatie/laravel-backup": "5.5.*"
+        "spatie/laravel-backup": "^5.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~6.0",


### PR DESCRIPTION
spatie/laravel-backup 更新了，没有 5.5.* 了，现在是 ^5.0。