### PR TITLE
fix compatibility with laravel-backup v6

### DIFF
--- a/resources/views/index.blade.php
+++ b/resources/views/index.blade.php
@@ -94,7 +94,6 @@ $(function () {
                 <th>Name</th>
                 <th>Disk</th>
                 <th>Reachable</th>
-                <th>Healthy</th>
                 <th># of backups</th>
                 <th>Newest backup</th>
                 <th>Used storage</th>
@@ -105,13 +104,12 @@ $(function () {
                 <td>{{ $backup[0] }}</td>
                 <td>{{ $backup[1] }}</td>
                 <td>{{ $backup[2] }}</td>
-                <td>{{ $backup[3] }}</td>
                 <td>{{ $backup['amount'] }}</td>
                 <td>{{ $backup['newest'] }}</td>
                 <td>{{ $backup['usedStorage'] }}</td>
             </tr>
             <tr class="collapse" id="trace-{{$index+1}}">
-                <td colspan="8">
+                <td colspan="7">
                     <ul class="todo-list ui-sortable">
                         @foreach($backup['files'] as $file)
                         <li>

--- a/src/Backup.php
+++ b/src/Backup.php
@@ -12,7 +12,7 @@ class Backup extends Extension
 {
     public function getExists()
     {
-        $statuses = BackupDestinationStatusFactory::createForMonitorConfig(config('backup.monitorBackups'));
+        $statuses = BackupDestinationStatusFactory::createForMonitorConfig(config('backup.monitor_backups'));
 
         $listCommand = new ListCommand();
 


### PR DESCRIPTION
// This update will fix incompatibility in the changes made to laravel-backup config file
Argument 1 passed to Spatie\Backup\Tasks\Monitor\BackupDestinationStatusFactory::createForMonitorConfig() must be of the type array, null given, called in .../vendor/laravel-admin-ext/backup/src/Backup.php on line 15 

// Last element called in the array passed to backup view does not exist- There's length inconsistency
Facade\Ignition\Exceptions\ViewException
Undefined offset: 3 (View: .../vendor/laravel-admin-ext/backup/resources/views/index.blade.php)
